### PR TITLE
fix: pin bottom SECRET banner and size project tags to their labels

### DIFF
--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -2,6 +2,7 @@
 html, body { margin: 0; height: 100%; }
 body {
   min-height: 100%;
+  display: flex; flex-direction: column;
   font-family: "Roboto", system-ui, sans-serif;
   color: #fff;
   background: #000 url("../img/lcars0-1377x1080.webp") center / cover no-repeat fixed;
@@ -13,7 +14,8 @@ body::before {
 }
 .wrap {
   position: relative; z-index: 1;
-  max-width: 34rem; margin: 0 auto; padding: 3rem 1.25rem;
+  flex: 1 0 auto;
+  width: 100%; max-width: 34rem; margin: 0 auto; padding: 3rem 1.25rem;
   display: flex; flex-direction: column; gap: 1.5rem; align-items: center;
 }
 .avatar {
@@ -26,6 +28,13 @@ body::before {
 .social { display: flex; flex-wrap: wrap; gap: 0.75rem; justify-content: center; }
 .social svg { width: 1.1em; height: 1.1em; vertical-align: -0.15em; margin-inline-end: 0.4em; }
 .tags { display: flex; flex-wrap: wrap; gap: 0.5rem; margin: 0.75rem 0 1rem; }
+/* rux-tag defaults to a fixed 3.75rem placeholder box; size it to its label
+   and give inline padding that scales with the (larger) font. */
+.tags rux-tag {
+  width: auto; height: auto;
+  font-size: 1rem;
+  padding-block: 0.3em; padding-inline: 0.9em;
+}
 rux-card { width: 100%; }
 /* Anchors wrapping rux-button: reset link chrome, no layout shift. */
 .btn-link { display: inline-flex; text-decoration: none; color: inherit; }


### PR DESCRIPTION
## Summary

Two UI fixes on the profile card:

- **Bottom SECRET banner** now pins to the bottom of the window. `<body>` is a flex column with `.wrap` set to `flex: 1 0 auto`, so the content region grows to fill the viewport and pushes the bottom classification marking to the actual bottom edge (previously it floated just under the card on short pages).
- **Project tags** (`rux-tag`) are sized to their labels. A bare `<rux-tag>` picks up the component's internal `is-undefined` placeholder state, which hard-codes `width: 3.75rem; height: 1.5rem` — narrower than labels like "Terraform"/"PostgreSQL", so the text overflowed the box. Overridden from `site.css` with `width/height: auto`, a larger font, and **em-based** inline padding so leading/trailing space scales with the font.

Scope is a single file: `src/styles/site.css`.

## Testing

Previewed locally (`python3 -m http.server -d src`) with `data-env="staging"` to reveal the banners, at both short and tall viewports — bottom banner stays pinned, tags no longer overflow. The committed `index.html` keeps `data-env="production"`.

Co-authored-by Claude